### PR TITLE
Minor - accounting for codegangsta/cli migration to urfave/cli

### DIFF
--- a/cmd/cfops/createCliCommand.go
+++ b/cmd/cfops/createCliCommand.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/codegangsta/cli"
 	"github.com/pivotalservices/cfbackup/tileregistry"
+	"github.com/urfave/cli"
 	"github.com/xchapter7x/lo"
 )
 

--- a/cmd/cfops/createCliCommand_test.go
+++ b/cmd/cfops/createCliCommand_test.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/cmd/cfops/help.go
+++ b/cmd/cfops/help.go
@@ -1,6 +1,7 @@
 package main
 
 const (
+	//CfopsHelpTemplate holds the help structure of CLI
 	CfopsHelpTemplate = `
 NAME:
    {{.Name}} - {{.Usage}}

--- a/cmd/cfops/main.go
+++ b/cmd/cfops/main.go
@@ -4,16 +4,19 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/codegangsta/cli"
 	"github.com/pivotalservices/cfbackup/tileregistry"
 	_ "github.com/pivotalservices/cfbackup/tiles"
 	_ "github.com/pivotalservices/cfops/plugin/load"
+	"github.com/urfave/cli"
 )
 
 var (
+	//VERSION holds information about the version of the project
 	VERSION string
 )
 
+//ErrorHandler holds the exit code and any message after the
+// command execution
 type ErrorHandler struct {
 	ExitCode int
 	Error    error
@@ -48,7 +51,7 @@ func NewApp(eh *ErrorHandler) *cli.App {
 			Usage: "shows a list of available backup/restore target tiles",
 			Action: func(c *cli.Context) error {
 				fmt.Println("Available Tiles:")
-				for n, _ := range tileregistry.GetRegistry() {
+				for n := range tileregistry.GetRegistry() {
 					fmt.Println(n)
 				}
 				return nil

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,8 @@
-hash: 59faa00f0caa2016f7937036a0c5cd7ad9dc05d4dc894d1bac40d59bd5f5e6c7
-updated: 2016-05-31T17:07:26.745808826-04:00
+hash: 38f9789d89ca00b55db1394fc440c6b35302f60decee79be68a235041354f224
+updated: 2016-06-01T14:24:16.303518674-07:00
 imports:
 - name: github.com/cloudfoundry-community/go-cfenv
   version: 96ad7376813bfd13c95af69ca5b4ef5725f6b335
-- name: github.com/codegangsta/cli
-  version: 9a18ffad6c548ca4d458d4c30a8aa4d181cf92fa
 - name: github.com/golang/protobuf
   version: 9e6977f30c91c78396e719e164e57f9287fff42c
   subpackages:
@@ -53,6 +51,8 @@ imports:
   version: 39f5507f61031141057f3f880d9fb9eb97b8afd7
 - name: github.com/technoweenie/multipartstreamer
   version: a90a01d73ae432e2611d178c18367fbaa13e0154
+- name: github.com/urfave/cli
+  version: 1433f8165e5413e63d8ade93530111c5a1f71a6a
 - name: github.com/xchapter7x/goutil
   version: 046742e03686eda64c6ac938594120d7fb5b3ecc
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/pivotalservices/cfops
 import:
 - package: github.com/cloudfoundry-community/go-cfenv
-- package: github.com/codegangsta/cli
+- package: github.com/urfave/cli
 - package: github.com/hashicorp/go-plugin
 - package: github.com/pivotalservices/cfbackup
   subpackages:


### PR DESCRIPTION
Very minor change - using this as a learning opportunity.

`codegangsta/cli` appears to have migrated over to `urfave/cli` as their new package instead, I have made that change across the board and as part of this change also fixed up some linting errors that I saw. 

Please review